### PR TITLE
Remove health services input

### DIFF
--- a/new_src/Doctor.cpp
+++ b/new_src/Doctor.cpp
@@ -44,12 +44,8 @@ Visit Doctor::performExamination() {
         std::cout << "drug: ";
     }
 
-    std::cout << "Enter health services (type 'done' to finish): ";
-    while (std::getline(std::cin, input)) {
-        if (input == "done") break;
-        if (!input.empty()) visit->hs.push_back(input);
-        std::cout << "service: ";
-    }
+    // Skipping input of additional health services as they are not required
+    // by current workflow. The list will remain empty.
 
     return *visit;
 }


### PR DESCRIPTION
## Summary
- remove interactive block that requested health services from doctor

## Testing
- `cmake .. && make -j$(nproc)`
- `./Patient_Queue`

------
https://chatgpt.com/codex/tasks/task_e_6847fc63c588832b928d30aa1a977278